### PR TITLE
Add web_allow_hosts to the config

### DIFF
--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -7,6 +7,11 @@ module Ngrok
   class FetchUrlError < StandardError; end
   class Error < StandardError; end
 
+
+  ALLOW_HOSTS = [
+    "localhost.test"
+  ].freeze
+
   class Tunnel
 
     class << self
@@ -131,9 +136,10 @@ module Ngrok
       def create_empty_config_file
         tmp = Tempfile.new('ngrok_config-')
         tmp << "version: ""2""\n"
+        tmp << "web_allow_hosts:\n"
+        ALLOW_HOSTS.each {|host| tmp << "  - #{host}\n"}
         tmp.flush
         tmp.close
-
         tmp
       end
     end

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -7,18 +7,14 @@ module Ngrok
   class FetchUrlError < StandardError; end
   class Error < StandardError; end
 
-
-  ALLOW_HOSTS = [
-    "localhost.test"
-  ].freeze
-
   class Tunnel
 
     class << self
       attr_reader :pid, :ngrok_url, :ngrok_url_https, :status
 
       def init(params = {})
-        @params = {addr: 3001, timeout: 10, config: create_empty_config_file.path}.merge(params)
+        allow_hosts = params[:allow_hosts] || []
+        @params = {addr: 3001, timeout: 10, config: create_empty_config_file(allow_hosts).path}.merge(params)
         @status = :stopped unless @status
       end
 
@@ -133,11 +129,11 @@ module Ngrok
         /^ngrok version [012]\./.match?(@version)
       end
 
-      def create_empty_config_file
+      def create_empty_config_file(allow_hosts)
         tmp = Tempfile.new('ngrok_config-')
         tmp << "version: ""2""\n"
         tmp << "web_allow_hosts:\n"
-        ALLOW_HOSTS.each {|host| tmp << "  - #{host}\n"}
+        allow_hosts.each {|host| tmp << "  - #{host}\n"}
         tmp.flush
         tmp.close
         tmp

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -132,8 +132,10 @@ module Ngrok
       def create_empty_config_file(allow_hosts)
         tmp = Tempfile.new('ngrok_config-')
         tmp << "version: ""2""\n"
-        tmp << "web_allow_hosts:\n"
-        allow_hosts.each {|host| tmp << "  - #{host}\n"}
+        if allow_hosts.any?
+          tmp << "web_allow_hosts:\n"
+          allow_hosts.each {|host| tmp << "  - #{host}\n"}
+        end
         tmp.flush
         tmp.close
         tmp


### PR DESCRIPTION
## What is in this PR?
As part of the latest version of ngrok ([changelog](https://ngrok.com/docs/ngrok-agent/changelog)) a new configuration was added and enforced.

> Added DNS rebinding protection which includes [web_allow_hosts](https://ngrok.com/docs/ngrok-agent/config#web_allow_hosts) configuration.

This PR adds an `allow_hosts` option so that other web hostnames can be used to inspect the tunnel.
![Screenshot 2023-01-27 at 9 57 05 AM](https://user-images.githubusercontent.com/10747839/215147245-c2efa13b-8023-4811-a429-83f32c1878fc.png)

## Before
![215147588-2135a5b1-eaad-4331-8b57-3b81f03886be](https://user-images.githubusercontent.com/10747839/215155589-4709d2a3-cd54-4ad4-b8d3-f5a2fc04ab63.png)

## After
![215147349-7ccae9c7-f02b-4908-86d7-319c478c830f](https://user-images.githubusercontent.com/10747839/215155908-be8549f4-7ce3-47c4-a6c3-28577119d69c.png)

## QA
Can test this by manually copy and pasting the changes into: `/Users/{USERNAME}/.rvm/gems/ruby-2.7.6/bundler/gems/ngrok-tunnel-c2bf7ddea04a/lib/ngrok/tunnel.rb` and then booting up the ngrok server. Then add `localhost.test` into a `allow_hosts` key when spinning up (starting) the tunnel

- [ ] The [ngrok inspect](http://localhost.test:4040/inspect/http) tool loads successfully for `localhost.test`
